### PR TITLE
Fix typed return for og-image getStaticPaths

### DIFF
--- a/src/pages/og-image/[...slug].png.ts
+++ b/src/pages/og-image/[...slug].png.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro";
 import satori from "satori";
 import { html } from "satori-html";
+import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
 import fs from "fs";
 import sharp from "sharp";
@@ -13,13 +14,20 @@ const surfaceColor = "white";
 const height = 630;
 const width = 1200;
 
+interface Params {
+  slug: string;
+}
+
+interface Props {
+  post: CollectionEntry<"blog">;
+}
+
 export async function getStaticPaths() {
   return (await getCollection("blog")).map(
-    (post) =>
-      ({
-        params: { slug: post.slug },
-        props: { post },
-      } as any)
+    (post): { params: Params; props: Props } => ({
+      params: { slug: post.slug },
+      props: { post },
+    })
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure `getStaticPaths` for dynamic OG images returns typed objects
- add explicit `Params`/`Props` interfaces

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fdc4746fc8320a3e33cf49f99e9ae