### PR TITLE
Add category pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,6 +7,7 @@ import HeaderLink from "./HeaderLink.astro";
     <div>
       <HeaderLink href="/">Home</HeaderLink>
       <HeaderLink href="/blog/">Blog</HeaderLink>
+      <HeaderLink href="/category/">Category</HeaderLink>
     </div>
   </nav>
 </header>

--- a/src/lib/category.ts
+++ b/src/lib/category.ts
@@ -1,0 +1,7 @@
+export function slugifyCategory(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+}

--- a/src/pages/category/[category].astro
+++ b/src/pages/category/[category].astro
@@ -1,0 +1,112 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import EmojiIcon from "../../components/EmojiIcon.astro";
+import FormattedDate from "../../components/FormattedDate.astro";
+import { SITE_TITLE } from "../../consts";
+import { getCollection } from "astro:content";
+import { slugifyCategory } from "../../lib/category";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  const map = new Map<string, string>();
+  for (const post of posts) {
+    for (const cat of post.data.category || []) {
+      const slug = slugifyCategory(cat);
+      if (!map.has(slug)) map.set(slug, cat);
+    }
+  }
+  return Array.from(map.entries()).map(([slug, name]) => ({
+    params: { category: slug },
+    props: { name },
+  }));
+}
+
+const { category } = Astro.params;
+const { name } = Astro.props;
+const posts = (await getCollection("blog", ({ data }) => !data.draft))
+  .filter((post) => post.data.category?.some((c) => slugifyCategory(c) === category))
+  .sort((a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf());
+const displayName = name ?? posts[0]?.data.category.find((c) => slugifyCategory(c) === category) ?? category;
+---
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <BaseHead title={`${displayName} - ${SITE_TITLE}`} />
+    <style>
+      .articleList {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+      }
+      .article {
+        width: 100%;
+      }
+      .hero {
+        display: flex;
+        color: var(--font-color-high-emphasis);
+      }
+      .heroIconArea {
+        width: 6rem;
+        font-size: 4em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .heroContentArea {
+        display: flex;
+        padding: 0.5em;
+        margin-left: 1rem;
+        flex: 1;
+        overflow-wrap: anywhere;
+        flex-direction: column;
+      }
+      .heroContentArea * {
+        margin: 0;
+      }
+      .heroContentArea > * + * {
+        margin-top: 0.6em;
+      }
+      .heroContentMetaArea * {
+        color: var(--font-color-medium-emphasis);
+      }
+      .heroContentMetaArea > * + * {
+        margin-top: 0.1em;
+      }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>{displayName}</h1>
+      <div class="articleList fade-in">
+        {
+          posts.map((post) => (
+            <article class="article">
+              <a class="hero surface" href={`/blog/${post.slug}/`}>
+                <div class="heroIconArea">
+                  <EmojiIcon>{post.data.heroIcon}</EmojiIcon>
+                </div>
+                <div class="heroContentArea">
+                  <h2 class="title">{post.data.title}</h2>
+                  <div class="heroContentMetaArea">
+                    <div class="date">
+                      <FormattedDate date={post.data.createdAt} />
+                    </div>
+                    <div>{post.data.category?.map((c) => `#${c}`).join(" ")}</div>
+                  </div>
+                </div>
+              </a>
+            </article>
+          ))
+        }
+      </div>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/category/index.astro
+++ b/src/pages/category/index.astro
@@ -1,0 +1,53 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { SITE_TITLE } from "../../consts";
+import { getCollection } from "astro:content";
+import { slugifyCategory } from "../../lib/category";
+
+const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
+  (a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf()
+);
+const map = new Map<string, { name: string; slug: string; count: number }>();
+for (const post of posts) {
+  for (const cat of post.data.category || []) {
+    const slug = slugifyCategory(cat);
+    const entry = map.get(slug) || { name: cat, slug, count: 0 };
+    if (!map.has(slug)) {
+      map.set(slug, entry);
+    }
+    entry.count++;
+  }
+}
+const categories = Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+---
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <BaseHead title={`${SITE_TITLE} Categories`} />
+    <style>
+      .list {
+        list-style-type: none;
+        padding: 0;
+      }
+      .list li + li {
+        margin-top: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main class="fade-in">
+      <h1>Categories</h1>
+      <ul class="list">
+        {categories.map((c) => (
+          <li>
+            <a href={`/category/${c.slug}/`}>{c.name} ({c.count})</a>
+          </li>
+        ))}
+      </ul>
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- list categories from posts
- show posts for a specific category
- link to the category index from the header

## Testing
- `pnpm install`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68401554f26c8320ba7d7b7153417dab