### PR TITLE
Add build check to PR workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: Lint and Format Check
+name: Lint, Format and Build Check
 
 on:
   pull_request:
@@ -37,3 +37,6 @@ jobs:
         run: |
           pnpm run format
           git diff --exit-code
+
+      - name: Build
+        run: pnpm run build


### PR DESCRIPTION
## Summary
- check the build in PR workflow in addition to lint and format

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint` *(fails: Found 4 errors)*
- `pnpm run format`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68424858bbcc8320bea7da4b24337163