### PR TITLE
Fix lint errors with Biome

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 const today = new Date();
-import { execSync } from "child_process";
+import { execSync } from "node:child_process";
 let gitHash = "unknown";
 try {
 	gitHash = execSync("git rev-parse --short HEAD").toString().trim();

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { CollectionEntry, getCollection } from "astro:content";
+import { type CollectionEntry, getCollection } from "astro:content";
 import BlogPost from "../../layouts/BlogPost.astro";
 
 export async function getStaticPaths() {

--- a/src/pages/og-image/[...slug].png.ts
+++ b/src/pages/og-image/[...slug].png.ts
@@ -3,7 +3,7 @@ import satori from "satori";
 import { html } from "satori-html";
 import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
-import fs from "fs";
+import fs from "node:fs";
 import sharp from "sharp";
 
 const fontPath = "src/lib/NotoSansJP-SemiBold.ttf";
@@ -56,7 +56,7 @@ export async function GET({ params, props }: APIContext) {
     </div>
   </div>`;
 
-	let svg = await satori(out, {
+	const svg = await satori(out, {
 		fonts: [
 			{
 				name: "NotoSansJapanese",


### PR DESCRIPTION
## Summary
- run Biome lint with `--write --unsafe`
- update imports to use `node:` protocol
- mark `CollectionEntry` as `type` import
- make `svg` a constant

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68427b4de4c48320bbcef369bbc65471