### PR TITLE
Move tag pages under blog section

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,7 +7,6 @@ import HeaderLink from "./HeaderLink.astro";
     <div>
       <HeaderLink href="/">Home</HeaderLink>
       <HeaderLink href="/blog/">Blog</HeaderLink>
-      <HeaderLink href="/tag/">Tag</HeaderLink>
     </div>
   </nav>
 </header>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,7 +5,6 @@ import Footer from "../../components/Footer.astro";
 import { SITE_TITLE } from "../../consts";
 import { getCollection } from "astro:content";
 import PostList from "../../components/PostList.astro";
-import EmojiIcon from "../../components/EmojiIcon.astro";
 
 const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
 	(a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf(),
@@ -24,15 +23,21 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
       crossorigin
     />
     <style>
-      .tag-link { text-align: right; margin: 1rem 0; }
-      .tag-link .tag { display: inline-block; padding: 0.3rem 0.6rem; background: var(--surface); border-radius: var(--surface-radius); text-decoration: none; color: inherit; box-shadow: 0 2px 6px rgba(var(--gray), 25%); }
+      .tag-link { text-align: right; margin: 0.5rem 0; }
+      .tag {
+        color: var(--link-color);
+      }
+      .tag:hover {
+        color: var(--link-hover-color);
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>
     <Header />
     <main>
         <div class="tag-link">
-          <a href="/blog/tag/" class="tag"><EmojiIcon>🏷️</EmojiIcon> Tags</a>
+          <a href="/blog/tag/" class="tag"> All Tags </a>
         </div>
       <PostList posts={posts} class="fade-in" />
     </main>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,6 +5,7 @@ import Footer from "../../components/Footer.astro";
 import { SITE_TITLE } from "../../consts";
 import { getCollection } from "astro:content";
 import PostList from "../../components/PostList.astro";
+import EmojiIcon from "../../components/EmojiIcon.astro";
 
 const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
 	(a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf(),
@@ -22,10 +23,17 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
       type="font/ttf"
       crossorigin
     />
+    <style>
+      .tag-link { text-align: right; margin: 1rem 0; }
+      .tag-link .tag { display: inline-block; padding: 0.3rem 0.6rem; background: var(--surface); border-radius: var(--surface-radius); text-decoration: none; color: inherit; box-shadow: 0 2px 6px rgba(var(--gray), 25%); }
+    </style>
   </head>
   <body>
     <Header />
     <main>
+        <div class="tag-link">
+          <a href="/blog/tag/" class="tag"><EmojiIcon>🏷️</EmojiIcon> Tags</a>
+        </div>
       <PostList posts={posts} class="fade-in" />
     </main>
     <Footer />

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,12 +1,12 @@
 ---
-import BaseHead from "../../components/BaseHead.astro";
-import Header from "../../components/Header.astro";
-import Footer from "../../components/Footer.astro";
-import { SITE_TITLE } from "../../consts";
+import BaseHead from "../../../components/BaseHead.astro";
+import Header from "../../../components/Header.astro";
+import Footer from "../../../components/Footer.astro";
+import { SITE_TITLE } from "../../../consts";
 import { getCollection } from "astro:content";
-import PostList from "../../components/PostList.astro";
-import { slugifyTag } from "../../lib/tag";
-import EmojiIcon from "../../components/EmojiIcon.astro";
+import PostList from "../../../components/PostList.astro";
+import { slugifyTag } from "../../../lib/tag";
+import EmojiIcon from "../../../components/EmojiIcon.astro";
 
 export async function getStaticPaths() {
 	const posts = await getCollection("blog", ({ data }) => !data.draft);

--- a/src/pages/blog/tag/index.astro
+++ b/src/pages/blog/tag/index.astro
@@ -1,11 +1,11 @@
 ---
-import BaseHead from "../../components/BaseHead.astro";
-import Header from "../../components/Header.astro";
-import Footer from "../../components/Footer.astro";
-import { SITE_TITLE } from "../../consts";
+import BaseHead from "../../../components/BaseHead.astro";
+import Header from "../../../components/Header.astro";
+import Footer from "../../../components/Footer.astro";
+import { SITE_TITLE } from "../../../consts";
 import { getCollection } from "astro:content";
-import { slugifyTag } from "../../lib/tag";
-import EmojiIcon from "../../components/EmojiIcon.astro";
+import { slugifyTag } from "../../../lib/tag";
+import EmojiIcon from "../../../components/EmojiIcon.astro";
 
 const posts = (await getCollection("blog", ({ data }) => !data.draft)).sort(
 	(a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf(),
@@ -53,7 +53,7 @@ const tags = Array.from(map.values()).sort((a, b) =>
     <ul class="list">
       {tags.map((c) => (
         <li>
-          <a href={`/tag/${c.slug}/`} class="tag">
+          <a href={`/blog/tag/${c.slug}/`} class="tag">
             <EmojiIcon>🏷️</EmojiIcon> {c.name} ({c.count})
           </a>
         </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,7 @@
 	--back-ground: var(--gray-100);
 	--surface: white;
 	--surface-radius: 8px;
+	--link-color: var(--accent-dark);
 	--link-hover-color: var(--accent);
 	--font-color-emphasis: rgba(0, 0, 0, 0.87);
 	--font-color-medium-emphasis: rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
## Summary
- move tag pages into `/blog/tag/`
- drop tag link from header
- link to tag listing from blog index

## Testing
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68428312c6e08320ac6003c9fd5700ec