### PR TITLE
Show tag icon links on posts

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": []
+		"ignore": ["dist/", ".astro/"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content";
 import EmojiIcon from "./EmojiIcon.astro";
 import FormattedDate from "./FormattedDate.astro";
+import { slugifyTag } from "../lib/tag";
 
 const { posts, class: className = "" } = Astro.props as {
 	posts: CollectionEntry<"blog">[];
@@ -21,7 +22,13 @@ const { posts, class: className = "" } = Astro.props as {
             <div class="date">
               <FormattedDate date={post.data.createdAt} />
             </div>
-            <div>{post.data.tags?.map((c) => `#${c}`).join(' ')}</div>
+            <div class="tags">
+              {post.data.tags?.map((tag) => (
+                <a href={`/blog/tag/${slugifyTag(tag)}/`} class="tag">
+                  <EmojiIcon>🏷️</EmojiIcon> {tag}
+                </a>
+              ))}
+            </div>
           </div>
         </div>
       </a>
@@ -71,5 +78,19 @@ const { posts, class: className = "" } = Astro.props as {
   }
   .heroContentMetaArea > * + * {
     margin-top: 0.1em;
+  }
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+  }
+  .tag {
+    display: inline-block;
+    padding: 0.3rem 0.6rem;
+    background: var(--surface);
+    border-radius: var(--surface-radius);
+    text-decoration: none;
+    color: inherit;
+    box-shadow: 0 2px 6px rgba(var(--gray), 25%);
   }
 </style>

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from "astro:content";
 import EmojiIcon from "./EmojiIcon.astro";
 import FormattedDate from "./FormattedDate.astro";
 import { slugifyTag } from "../lib/tag";
+import TagLink from "./TagLink.astro";
 
 const { posts, class: className = "" } = Astro.props as {
 	posts: CollectionEntry<"blog">[];
@@ -11,8 +12,9 @@ const { posts, class: className = "" } = Astro.props as {
 ---
 <div class={"articleList " + className}>
   {posts.map((post) => (
-    <article class="article">
-      <a class="hero surface" href={`/blog/${post.slug}/`}>
+    <div class="article">
+      <a class="postLink" href={`/blog/${post.slug}/`} />
+      <div class="hero surface">
         <div class="heroIconArea">
           <EmojiIcon>{post.data.heroIcon}</EmojiIcon>
         </div>
@@ -24,15 +26,13 @@ const { posts, class: className = "" } = Astro.props as {
             </div>
             <div class="tags">
               {post.data.tags?.map((tag) => (
-                <a href={`/blog/tag/${slugifyTag(tag)}/`} class="tag">
-                  <EmojiIcon>🏷️</EmojiIcon> {tag}
-                </a>
+                <TagLink tag={tag} href={`/blog/tag/${slugifyTag(tag)}/`} />
               ))}
             </div>
           </div>
         </div>
-      </a>
-    </article>
+      </div>
+    </div>
   ))}
 </div>
 <style>
@@ -47,6 +47,11 @@ const { posts, class: className = "" } = Astro.props as {
   }
   .article {
     width: 100%;
+    position: relative;
+  }
+  .postLink {
+    position: absolute;
+    inset: 0;
   }
   .hero {
     display: flex;
@@ -83,14 +88,6 @@ const { posts, class: className = "" } = Astro.props as {
     display: flex;
     flex-wrap: wrap;
     gap: 0.3rem;
-  }
-  .tag {
-    display: inline-block;
-    padding: 0.3rem 0.6rem;
-    background: var(--surface);
-    border-radius: var(--surface-radius);
-    text-decoration: none;
-    color: inherit;
-    box-shadow: 0 2px 6px rgba(var(--gray), 25%);
+    position: relative;
   }
 </style>

--- a/src/components/TagLink.astro
+++ b/src/components/TagLink.astro
@@ -1,0 +1,35 @@
+---
+import EmojiIcon from "./EmojiIcon.astro";
+
+interface Props {
+	href: string;
+	tag: string;
+}
+const { tag, href } = Astro.props;
+---
+<a href={href} class="tagLink">
+  <div class="tagIconArea">
+    <EmojiIcon>🏷️</EmojiIcon>
+  </div>
+  <span class="tag">{tag}</span>
+</a>
+<style>
+  .tagIconArea {
+    width: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .tagLink {
+    display: inline-flex;
+  }
+  .tagLink:hover {
+    text-decoration: underline;
+  }
+  .tag {
+    color: var(--font-color-medium-emphasis);
+  }
+  .tag:hover {
+    color: var(--link-hover-color);
+  }
+</style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,6 +6,7 @@ import Footer from "../components/Footer.astro";
 import FormattedDate from "../components/FormattedDate.astro";
 import EmojiIcon from "../components/EmojiIcon.astro";
 import { slugifyTag } from "../lib/tag";
+import TagLink from "../components/TagLink.astro";
 
 type Props = CollectionEntry<"blog">["data"] & { slug: string };
 
@@ -170,9 +171,7 @@ const image = `/og-image/${slug}.png`;
               }
               <div class="tags">
                 {tags?.map((tag) => (
-                  <a href={`/blog/tag/${slugifyTag(tag)}/`} class="tag">
-                    <EmojiIcon>🏷️</EmojiIcon> {tag}
-                  </a>
+                  <TagLink tag={tag} href={`/blog/tag/${slugifyTag(tag)}/`} />
                 ))}
               </div>
             </div>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,6 +5,7 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import FormattedDate from "../components/FormattedDate.astro";
 import EmojiIcon from "../components/EmojiIcon.astro";
+import { slugifyTag } from "../lib/tag";
 
 type Props = CollectionEntry<"blog">["data"] & { slug: string };
 
@@ -38,6 +39,21 @@ const image = `/og-image/${slug}.png`;
       }
       .meta > * + * {
         margin-top: 0.1em;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3rem;
+        justify-content: flex-end;
+      }
+      .tag {
+        display: inline-block;
+        padding: 0.3rem 0.6rem;
+        background: var(--surface);
+        border-radius: var(--surface-radius);
+        text-decoration: none;
+        color: inherit;
+        box-shadow: 0 2px 6px rgba(var(--gray), 25%);
       }
 
       /* Blog Content */
@@ -152,7 +168,13 @@ const image = `/og-image/${slug}.png`;
                   </div>
                 )
               }
-              <div>{tags?.map((c) => `#${c}`).join(" ")}</div>
+              <div class="tags">
+                {tags?.map((tag) => (
+                  <a href={`/blog/tag/${slugifyTag(tag)}/`} class="tag">
+                    <EmojiIcon>🏷️</EmojiIcon> {tag}
+                  </a>
+                ))}
+              </div>
             </div>
             <hr class="border" />
           </div>


### PR DESCRIPTION
## Summary
- replace text tag list with icon links to tag search pages
- apply same style from tag index

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_6842905c5cc08320863f6eb90355cd5f