### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary
- configure Dependabot for weekly updates of npm packages and GitHub Actions

## Testing
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843d098e3a88320abaf7197388842a3