### PR TITLE
Add code block title support

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import mdx from "@astrojs/mdx";
 import partytown from "@astrojs/partytown";
 
 import sitemap from "@astrojs/sitemap";
+import remarkCodeTitles from "remark-code-titles";
 
 export default defineConfig({
 	site: "https://blog.kenta-ja8.com",
@@ -17,4 +18,7 @@ export default defineConfig({
 			},
 		}),
 	],
+	markdown: {
+		remarkPlugins: [remarkCodeTitles],
+	},
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,5 +20,8 @@ export default defineConfig({
 	],
 	markdown: {
 		remarkPlugins: [remarkCodeTitles],
+		shikiConfig: {
+			theme: "github-dark-dimmed",
+		},
 	},
 });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@astrojs/partytown": "^2.1.4",
 		"@biomejs/biome": "^1.9.4",
 		"@types/sharp": "^0.32.0",
-		"pnpm": "^10.11.1"
+		"pnpm": "^10.11.1",
+		"remark-code-titles": "^0.1.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       pnpm:
         specifier: ^10.11.1
         version: 10.11.1
+      remark-code-titles:
+        specifier: ^0.1.2
+        version: 0.1.2
 
 packages:
 
@@ -1695,6 +1698,9 @@ packages:
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
 
+  remark-code-titles@0.1.2:
+    resolution: {integrity: sha512-KsHQbaI4FX8Ozxqk7YErxwmBiveUqloKuVqyPG2YPLHojpgomodWgRfG4B+bOtmn/5bfJ8khw4rR0lvgVFl2Uw==}
+
   remark-gfm@4.0.0:
     resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
 
@@ -1906,6 +1912,9 @@ packages:
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
+  unist-util-is@3.0.0:
+    resolution: {integrity: sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==}
+
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
 
@@ -1927,8 +1936,14 @@ packages:
   unist-util-visit-children@3.0.0:
     resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
 
+  unist-util-visit-parents@2.1.2:
+    resolution: {integrity: sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==}
+
   unist-util-visit-parents@6.0.1:
     resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@1.4.1:
+    resolution: {integrity: sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==}
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
@@ -4164,6 +4179,10 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
+  remark-code-titles@0.1.2:
+    dependencies:
+      unist-util-visit: 1.4.1
+
   remark-gfm@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4515,6 +4534,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
 
+  unist-util-is@3.0.0: {}
+
   unist-util-is@6.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -4545,10 +4566,18 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  unist-util-visit-parents@2.1.2:
+    dependencies:
+      unist-util-is: 3.0.0
+
   unist-util-visit-parents@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
+
+  unist-util-visit@1.4.1:
+    dependencies:
+      unist-util-visit-parents: 2.1.2
 
   unist-util-visit@5.0.0:
     dependencies:

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -116,7 +116,7 @@ we can use 3 backticks ``` in new line and write snippet and close with 3 backti
 
 Output
 
-```html
+```html:index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -100,7 +100,7 @@ The blockquote element represents content that is quoted from another source, op
 we can use 3 backticks ``` in new line and write snippet and close with 3 backticks on new line and to highlight language specific syntac, write one word of language name after first 3 backticks, for eg. html, javascript, css, markdown, typescript, txt, bash
 
 ````markdown
-```html
+```html:index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -137,6 +137,15 @@ const image = `/og-image/${slug}.png`;
         padding: 1em;
         border-radius: 8px;
       }
+      .contentBox :global(.remark-code-title) {
+        margin: 1em 0 -0.8em 0;
+        padding: 0.3em 0.6em;
+        font-size: 0.9em;
+        background: var(--gray-200);
+        border-top-left-radius: 8px;
+        border-top-right-radius: 8px;
+        width: fit-content;
+      }
       .contentBox :global(code:not(pre code)) {
         padding: 0.2em 0.2em;
         margin: 0 0.1em;

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -138,10 +138,11 @@ const image = `/og-image/${slug}.png`;
         border-radius: 8px;
       }
       .contentBox :global(.remark-code-title) {
-        margin: 1em 0 -0.8em 0;
-        padding: 0.3em 0.6em;
-        font-size: 0.9em;
-        background: var(--gray-200);
+        margin: 1em 0 -1.2em 0;
+        padding: 0.8em 0.8em;
+        font-size: 0.7em;
+        background: var(--gray-700);
+        color: white;
         border-top-left-radius: 8px;
         border-top-right-radius: 8px;
         width: fit-content;


### PR DESCRIPTION
## Summary
- show filenames above code blocks
- include `remark-code-titles` for parsing `lang:filename` syntax
- tweak blog layout to style the code titles
- document feature in markdown style guide

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_6872098343608320b496e44e483bc720