### PR TITLE
Add remark-code-titles plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
+import remarkCodeTitles from "./plugins/remark-code-titles";
 import partytown from "@astrojs/partytown";
 
 import sitemap from "@astrojs/sitemap";
@@ -9,7 +10,9 @@ export default defineConfig({
 	trailingSlash: "always",
 	vite: { optimizeDeps: { exclude: ["@resvg/resvg-js"] } },
 	integrations: [
-		mdx(),
+		mdx({
+			remarkPlugins: [remarkCodeTitles],
+		}),
 		sitemap(),
 		partytown({
 			config: {

--- a/plugins/remark-code-titles.ts
+++ b/plugins/remark-code-titles.ts
@@ -1,0 +1,44 @@
+import { visit } from "unist-util-visit";
+import type { Plugin } from "unified";
+import type { Code } from "mdast";
+import type { Parent } from "unist";
+
+export interface RemarkCodeTitleOptions {
+	className?: string;
+}
+
+const remarkCodeTitles: Plugin<[RemarkCodeTitleOptions?]> = (options = {}) => {
+	const className = options.className ?? "remark-code-title";
+
+	return (tree) => {
+		visit(
+			tree,
+			"code",
+			(node: Code, index: number, parent: Parent | undefined) => {
+				const nodeLang: string = node.lang || "";
+				if (!nodeLang.includes(" ")) {
+					return;
+				}
+
+				const [language, ...rest] = nodeLang.split(" ");
+				const title = rest.join(" ").trim();
+				if (!title) {
+					return;
+				}
+
+				const titleNode = {
+					type: "html",
+					value: `<div class="${className}">${title}</div>`,
+				};
+
+				if (parent && Array.isArray(parent.children)) {
+					parent.children.splice(index, 0, titleNode);
+				}
+
+				node.lang = language;
+			},
+		);
+	};
+};
+
+export default remarkCodeTitles;


### PR DESCRIPTION
## Summary
- implement custom remark plugin to add code titles separated by spaces
- register plugin in Astro MDX config

## Testing
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687220222f888320b7cec8939e325af0