### PR TITLE
Add concurrency to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: "deploy"
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
## Summary
- prevent simultaneous workflow executions by introducing a concurrency group

## Testing
- `pnpm run lint`
- `pnpm run format`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68731466f48483209a6cf4aaebdc3d17